### PR TITLE
Merge newtype macros to object reform

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -2,21 +2,26 @@ The Gtk-rs Project is copyright 2013-2015, The Gtk-rs Project Developers:
 
 Adam Crume <adamcrume@gmail.com>
 Anton Konjahin <koniahin.ant@yandex.ru>
+Arne Dussin <arne.dussin@live.de>
 Boden Garman <bpgarman@fastmail.fm>
 Brian Kropf <brian.kropf@gmail.com>
 Chris Greenaway <cjgreenaway@gmail.com>
+Chris Palmer <pennstate5013@gmail.com>
 Corey Farwell <coreyf@rwell.org>
 Daniel Zalevskiy <dndanik@gmail.com>
 Edward Shaw <edwardshaw9+git@gmail.com>
 Esption <esption@gmail.com>
 Evgenii Pashkin <eapashkin@gmail.com>
+Geoffrey French <frondit1985@gmail.com>
 Gleb Kozyrev <gleb@gkoz.com>
 Guillaume Gomez <guillaume1.gomez@gmail.com>
 Gulshan Singh <gulshan@umich.edu>
 Jakob Gillich <jakob@gillich.me>
 James Shepherdson <james.shepherdson@gmail.com>
 Jeremy Letang <letang.jeremy@gmail.com>
+John Vrbanac <john.vrbanac@linux.com>
 kennytm <kennytm@gmail.com>
+Laurence Tratt <laurie@tratt.net>
 Lionel Flandrin <lionel.flandrin@gmail.com>
 Lucas Werkmeister <mail@lucaswerkmeister.de>
 Lukas Diekmann <lukas.diekmann@gmail.com>
@@ -27,6 +32,7 @@ Nicolas Koch <nioko1337@gmail.com>
 Ömer Sinan Ağacan <omeragacan@gmail.com>
 Paul Dennis <paul_a_dennis@yahoo.com>
 Philipp Brüschweiler <blei42@gmail.com>
+Robertas <robertasjasmontas@gmail.com>
 Romain Gauthier <romain.gauthier@monkeypatch.me>
 S.J.R. van Schaik <stephan@synkhronix.com>
 Sebastian Schulze <me@bstr.eu>

--- a/src/app_info.rs
+++ b/src/app_info.rs
@@ -3,16 +3,13 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 use gio_ffi;
-use object::{GenericObject, Upcast};
-use translate::*;
-use types;
+use object::Upcast;
 
-pub type AppInfo = GenericObject<gio_ffi::GAppInfo>;
+glib_wrapper! {
+    pub struct AppInfo(Object<gio_ffi::GAppInfo>);
 
-impl types::StaticType for AppInfo {
-    #[inline]
-    fn static_type() -> types::Type {
-        unsafe { from_glib(gio_ffi::g_app_info_get_type()) }
+    match fn {
+        get_type => || gio_ffi::g_app_info_get_type(),
     }
 }
 

--- a/src/boxed.rs
+++ b/src/boxed.rs
@@ -2,9 +2,85 @@ use std::marker::PhantomData;
 use std::mem;
 use translate::*;
 
+/// Wrapper implementations for Boxed types. See `glib_wrapper!`.
+#[macro_export]
+macro_rules! glib_boxed_wrapper {
+    ([$($attr:meta)*] $name:ident, $ffi_name:path, @copy $copy_arg:ident $copy_expr:expr,
+     @free $free_arg:ident $free_expr:expr) => {
+        $(#[$attr])*
+        pub struct $name($crate::boxed::Boxed<$ffi_name, MemoryManager>);
+
+        #[doc(hidden)]
+        pub struct MemoryManager;
+
+        impl $crate::boxed::BoxedMemoryManager<$ffi_name> for MemoryManager {
+            #[inline]
+            unsafe fn copy($copy_arg: *const $ffi_name) -> *mut $ffi_name {
+                $copy_expr
+            }
+
+            #[inline]
+            unsafe fn free($free_arg: *mut $ffi_name) {
+                $free_expr
+            }
+        }
+
+        impl $crate::translate::Uninitialized for $name {
+            #[inline]
+            unsafe fn uninitialized() -> Self {
+                $name($crate::boxed::Boxed::uninitialized())
+            }
+        }
+
+        impl<'a> $crate::translate::ToGlibPtr<'a, *const $ffi_name> for &'a $name {
+            type Storage = &'a $crate::boxed::Boxed<$ffi_name, MemoryManager>;
+
+            #[inline]
+            fn to_glib_none(&self) -> $crate::translate::Stash<'a, *const $ffi_name, Self> {
+                let stash = (&self.0).to_glib_none();
+                $crate::translate::Stash(stash.0, stash.1)
+            }
+        }
+
+        impl<'a> $crate::translate::ToGlibPtrMut<'a, *mut $ffi_name> for $name {
+            type Storage = &'a mut $crate::boxed::Boxed<$ffi_name, MemoryManager>;
+
+            #[inline]
+            fn to_glib_none_mut(&'a mut self) -> $crate::translate::StashMut<'a, *mut $ffi_name, Self> {
+                let stash = self.0.to_glib_none_mut();
+                $crate::translate::StashMut(stash.0, stash.1)
+            }
+        }
+
+        impl $crate::translate::FromGlibPtr<*mut $ffi_name> for $name {
+            #[inline]
+            unsafe fn from_glib_none(ptr: *mut $ffi_name) -> Self {
+                $name($crate::translate::from_glib_none(ptr))
+            }
+
+            #[inline]
+            unsafe fn from_glib_full(ptr: *mut $ffi_name) -> Self {
+                $name($crate::translate::from_glib_full(ptr))
+            }
+
+            #[inline]
+            unsafe fn from_glib_borrow(ptr: *mut $ffi_name) -> Self {
+                $name($crate::translate::from_glib_borrow(ptr))
+            }
+        }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                $name(self.0.clone())
+            }
+        }
+    }
+}
+
 enum AnyBox<T> {
     Native(Box<T>),
-    Foreign(*mut T),
+    ForeignOwned(*mut T),
+    ForeignBorrowed(*mut T),
 }
 
 /// Memory management functions for a boxed type.
@@ -24,6 +100,16 @@ pub struct Boxed<T: 'static, MM: BoxedMemoryManager<T>> {
 impl<T: 'static, MM: BoxedMemoryManager<T>> Boxed<T, MM> {
     #[inline]
     pub unsafe fn uninitialized() -> Self {
+        Boxed {
+            inner: AnyBox::Native(Box::new(mem::uninitialized())),
+            _dummy: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static, MM: BoxedMemoryManager<T>> Uninitialized for Boxed<T, MM> {
+    #[inline]
+    unsafe fn uninitialized() -> Self {
         Boxed { 
             inner: AnyBox::Native(Box::new(mem::uninitialized())),
             _dummy: PhantomData,
@@ -36,9 +122,10 @@ impl<'a, T: 'static, MM: BoxedMemoryManager<T>> ToGlibPtr<'a, *const T> for &'a 
 
     #[inline]
     fn to_glib_none(&self) -> Stash<'a, *const T, Self> {
+        use self::AnyBox::*;
         let ptr = match self.inner {
-            AnyBox::Native(ref b) => &**b as *const T,
-            AnyBox::Foreign(p) => p as *const T,
+            Native(ref b) => &**b as *const T,
+            ForeignOwned(p) | ForeignBorrowed(p) => p as *const T,
         };
         Stash(ptr, *self)
     }
@@ -49,9 +136,10 @@ impl<'a, T: 'static, MM: BoxedMemoryManager<T>> ToGlibPtrMut<'a, *mut T> for Box
 
     #[inline]
     fn to_glib_none_mut(&'a mut self) -> StashMut<'a, *mut T, Self> {
+        use self::AnyBox::*;
         let ptr = match self.inner {
-            AnyBox::Native(ref mut b) => &mut **b as *mut T,
-            AnyBox::Foreign(p) => p,
+            Native(ref mut b) => &mut **b as *mut T,
+            ForeignOwned(p) | ForeignBorrowed(p) => p,
         };
         StashMut(ptr, self)
     }
@@ -69,7 +157,16 @@ impl<T: 'static, MM: BoxedMemoryManager<T>> FromGlibPtr<*mut T> for Boxed<T, MM>
     unsafe fn from_glib_full(ptr: *mut T) -> Self {
         assert!(!ptr.is_null());
         Boxed {
-            inner: AnyBox::Foreign(ptr),
+            inner: AnyBox::ForeignOwned(ptr),
+            _dummy: PhantomData,
+        }
+    }
+
+    #[inline]
+    unsafe fn from_glib_borrow(ptr: *mut T) -> Self {
+        assert!(!ptr.is_null());
+        Boxed {
+            inner: AnyBox::ForeignBorrowed(ptr),
             _dummy: PhantomData,
         }
     }
@@ -79,7 +176,7 @@ impl<T: 'static, MM: BoxedMemoryManager<T>> Drop for Boxed<T, MM> {
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            if let AnyBox::Foreign(ptr) = self.inner {
+            if let AnyBox::ForeignOwned(ptr) = self.inner {
                 MM::free(ptr);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,114 @@ pub use self::value::{Value, ValuePublic};
 pub use types::Type;
 pub use self::date::{TimeVal, Time, Date, Year, Month, Weekday, Day};
 
+/// Defines a wrapper type and implements the appropriate traits.
+///
+/// The basic syntax is
+///
+/// ```ignore
+/// glib_wrapper! {
+///     /// Documentation
+///     pub struct $name($kind<$foreign>);
+///
+///     match fn {
+///         $fn_name => /* a closure-like expression */,
+///         ...
+///     }
+/// }
+/// ```
+///
+/// This creates a wrapper named `$name` around the foreign type `$foreign`
+/// of $kind (one of `Boxed`, `Object`) using expressions from the `match fn`
+/// block to implement type-specific low-level operations. The expression
+/// will be evaluated in `unsafe` context.
+///
+/// ### Boxed
+///
+/// ```ignore
+/// glib_wrapper! {
+///     /// Text buffer iterator
+///     pub struct TextIter(Boxed<ffi::GtkTextIter>);
+///
+///     match fn {
+///         copy => |ptr| ffi::gtk_text_iter_copy(ptr),
+///         free => |ptr| ffi::gtk_text_iter_free(ptr),
+///     }
+/// }
+/// ```
+///
+/// `copy`: `|*const $foreign| -> *mut $foreign` creates a copy of the value.
+///
+/// `free`: `|*mut $foreign|` frees the value.
+///
+/// ### Object
+///
+/// ```
+/// glib_wrapper! {
+///     /// Object representing an input device.
+///     pub struct Device(Object<ffi::GdkDevice>);
+///
+///     match fn {
+///         get_type => || ffi::gdk_device_get_type(),
+///     }
+/// }
+/// ```
+///
+/// ```
+/// glib_wrapper! {
+///     /// A container with just one child.
+///     pub struct Bin(Object<ffi::GtkBin>): Container, Widget, Buildable;
+///
+///     match fn {
+///         get_type => || ffi::gtk_bin_get_type(),
+///     }
+/// }
+/// ```
+///
+/// `get_type: || -> GType` returns the type identifier of the class.
+#[macro_export]
+macro_rules! glib_wrapper {
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(Boxed<$ffi_name:path>);
+
+        match fn {
+            copy => |$copy_arg:ident| $copy_expr:expr,
+            free => |$free_arg:ident| $free_expr:expr,
+        }
+    ) => {
+        glib_boxed_wrapper!([$($attr)*] $name, $ffi_name, @copy $copy_arg $copy_expr,
+            @free $free_arg $free_expr);
+    };
+
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(Object<$ffi_name:path>);
+
+        match fn {
+            get_type => || $get_type_expr:expr,
+        }
+    ) => {
+        glib_object_wrapper!([$($attr)*] $name, $ffi_name, @get_type $get_type_expr, []);
+    };
+
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident(Object<$ffi_name:path>): $($implements:path),+;
+
+        match fn {
+            get_type => || $get_type_expr:expr,
+        }
+    ) => {
+        glib_object_wrapper!([$($attr)*] $name, $ffi_name, @get_type $get_type_expr,
+            [$($implements),+]);
+    };
+}
+
+#[macro_use]
+pub mod boxed;
+#[macro_use]
+pub mod object;
+
 mod app_info;
 mod list;
 mod slist;
@@ -36,8 +144,7 @@ pub mod source;
 pub mod traits;
 pub mod translate;
 mod value;
-pub mod boxed;
-pub mod object;
+
 pub mod types;
 pub mod date;
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -222,25 +222,48 @@ pub trait ObjectExt {
 impl<T: Upcast<Object>> ObjectExt for T {
 }
 
-/// The crate-local generic type for `GObject` descendants in GLib.
-#[derive(Debug)]
-pub struct GenericObject<T>(Ref, PhantomData<T>);
+/// Wrapper implementations for Object types. See `glib_wrapper!`.
+#[macro_export]
+macro_rules! glib_object_wrapper {
+    ([$($attr:meta)*] $name:ident, $ffi_name:path, @get_type $get_type_expr:expr,
+     [$($implements:path),*]) => {
+        $(#[$attr])*
+        pub struct $name($crate::object::Ref, ::std::marker::PhantomData<$ffi_name>);
 
-impl<T: 'static> Wrapper for GenericObject<T> where GenericObject<T>: StaticType {
-    type GlibType = T;
-    #[inline]
-    unsafe fn wrap(r: Ref) -> GenericObject<T> { GenericObject(r, PhantomData) }
-    #[inline]
-    fn as_ref(&self) -> &Ref { &self.0 }
-    #[inline]
-    fn unwrap(self) -> Ref { self.0 }
-}
+        impl $crate::object::Wrapper for $name {
+            type GlibType = $ffi_name;
 
-impl<T> Clone for GenericObject<T> {
-    #[inline]
-    fn clone(&self) -> GenericObject<T> {
-        GenericObject(self.0.clone(), PhantomData)
+            #[inline]
+            unsafe fn wrap(r: $crate::object::Ref) -> Self {
+                $name(r, ::std::marker::PhantomData)
+            }
+
+            #[inline]
+            fn as_ref(&self) -> &$crate::object::Ref {
+                &self.0
+            }
+
+            #[inline]
+            fn unwrap(self) -> $crate::object::Ref {
+                self.0
+            }
+        }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                $name(self.0.clone(), ::std::marker::PhantomData)
+            }
+        }
+
+        impl $crate::types::StaticType for $name {
+            fn static_type() -> $crate::types::Type {
+                unsafe { $crate::translate::from_glib($get_type_expr) }
+            }
+        }
+
+        unsafe impl $crate::object::Upcast<$crate::object::Object> for $name { }
+        $(
+            unsafe impl $crate::object::Upcast<$implements> for $name { }
+        )*
     }
 }
-
-unsafe impl<T: 'static> Upcast<Object> for GenericObject<T> where GenericObject<T>: StaticType { }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -9,7 +9,7 @@ use translate::ToGlibPtr;
 
 pub unsafe fn connect(receiver: *mut gobject_ffi::GObject, signal_name: &str, trampoline: GCallback,
                       closure: *mut Box<Fn() + 'static>) -> u64 {
-    let handle = gobject_ffi::g_signal_connect_data(receiver as *mut _, signal_name.to_glib_none().0,
+    let handle = gobject_ffi::g_signal_connect_data(receiver, signal_name.to_glib_none().0,
         trampoline, closure as *mut _, Some(destroy_closure),
         gobject_ffi::GConnectFlags::empty()) as u64;
     assert!(handle > 0);

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -76,6 +76,47 @@ impl<T: 'static> Ptr for *mut T {
     fn from<X>(ptr: *mut X) -> *mut T { ptr as *mut T }
 }
 
+/// A trait for creating an uninitialized value. Handy for receiving outparams.
+pub trait Uninitialized {
+    /// Returns an uninitialized value.
+    unsafe fn uninitialized() -> Self;
+}
+
+/// Returns an uninitialized value.
+#[inline]
+pub unsafe fn uninitialized<T: Uninitialized>() -> T {
+    T::uninitialized()
+}
+
+pub trait ToBool: Copy {
+    fn to_bool(self) -> bool;
+}
+
+impl ToBool for bool {
+    #[inline]
+    fn to_bool(self) -> bool {
+        self
+    }
+}
+
+impl ToBool for glib_ffi::gboolean {
+    #[inline]
+    fn to_bool(self) -> bool {
+        !(self == glib_ffi::GFALSE)
+    }
+}
+
+/// Returns `Some(val)` if the condition is true and `None` otherwise.
+#[inline]
+pub fn some_if<B: ToBool, T>(cond: B, val: T) -> Option<T> {
+    if cond.to_bool() {
+        Some(val)
+    }
+    else {
+        None
+    }
+}
+
 // a terrible hack to support null-terminated arrays of `c_int` and `GType`
 
 impl Ptr for i32 {
@@ -213,13 +254,6 @@ pub trait ToGlibPtrMut<'a, P: Copy> {
     ///
     /// The pointer in the `Stash` is only valid for the lifetime of the `Stash`.
     fn to_glib_none_mut(&'a mut self) -> StashMut<P, Self>;
-
-    /// Transfer: full.
-    ///
-    /// We transfer the ownership to the foreign library.
-    fn to_glib_full_mut(&'a mut self) -> P {
-        unimplemented!();
-    }
 }
 
 impl <'a, P: Ptr, T: ToGlibPtr<'a, P>> ToGlibPtr<'a, P> for Option<T> {
@@ -236,6 +270,18 @@ impl <'a, P: Ptr, T: ToGlibPtr<'a, P>> ToGlibPtr<'a, P> for Option<T> {
     #[inline]
     fn to_glib_full(&self) -> P {
         self.as_ref().map_or(Ptr::from::<()>(ptr::null_mut()), |s| s.to_glib_full())
+    }
+}
+
+impl <'a, 'opt: 'a, P: Ptr, T: ToGlibPtrMut<'a, P>> ToGlibPtrMut<'a, P> for Option<&'opt mut T> {
+    type Storage = Option<<T as ToGlibPtrMut<'a, P>>::Storage>;
+
+    #[inline]
+    fn to_glib_none_mut(&'a mut self) -> StashMut<'a, P, Option<&'opt mut T>> {
+        self.as_mut().map_or(StashMut(Ptr::from::<()>(ptr::null_mut()), None), |s| {
+            let s = s.to_glib_none_mut();
+            StashMut(s.0, Some(s.1))
+        })
     }
 }
 
@@ -423,6 +469,11 @@ pub trait FromGlibPtr<P: Ptr>: Sized {
 
     /// Transfer: full.
     unsafe fn from_glib_full(ptr: P) -> Self;
+
+    /// Borrow. Don't increase the refcount.
+    unsafe fn from_glib_borrow(_ptr: P) -> Self {
+        unimplemented!();
+    }
 }
 
 /// Translate from a pointer type, transfer: none.
@@ -435,6 +486,12 @@ pub unsafe fn from_glib_none<P: Ptr, T: FromGlibPtr<P>>(ptr: P) -> T {
 #[inline]
 pub unsafe fn from_glib_full<P: Ptr, T: FromGlibPtr<P>>(ptr: P) -> T {
     FromGlibPtr::from_glib_full(ptr)
+}
+
+/// Translate from a pointer type, borrowing the pointer.
+#[inline]
+pub unsafe fn from_glib_borrow<P: Ptr, T: FromGlibPtr<P>>(ptr: P) -> T {
+    FromGlibPtr::from_glib_borrow(ptr)
 }
 
 impl<P: Ptr, T: FromGlibPtr<P>> FromGlibPtr<P> for Option<T> {


### PR DESCRIPTION
For boxed record testing.
`glib_wrapper!` unchanged.